### PR TITLE
Feature implementation from commits a5deb26..d25055b

### DIFF
--- a/java/org/apache/catalina/connector/Connector.java
+++ b/java/org/apache/catalina/connector/Connector.java
@@ -210,7 +210,7 @@ public class Connector extends LifecycleMBeanBase {
      */
     protected int maxParameterCount = 1000;
 
-    private int maxPartCount = 10;
+    private int maxPartCount = 50;
 
     private int maxPartHeaderSize = 512;
 

--- a/java/org/apache/catalina/webresources/AbstractResourceSet.java
+++ b/java/org/apache/catalina/webresources/AbstractResourceSet.java
@@ -71,7 +71,11 @@ public abstract class AbstractResourceSet extends LifecycleBase implements WebRe
 
     public final void setWebAppMount(String webAppMount) {
         checkPath(webAppMount);
-        // Optimise internal processing
+        /*
+         * Originally, only "/" was changed to "" to allow some optimisations. The fix for CVE-2025-49125 means that
+         * mounted WebResourceSets will break if webAppMount ends in '/'. So now the trailing "/" is removed in all
+         * cases.
+         */
         if (webAppMount.endsWith("/")) {
             this.webAppMount = webAppMount.substring(0, webAppMount.length() - 1);
         } else {

--- a/java/org/apache/catalina/webresources/AbstractResourceSet.java
+++ b/java/org/apache/catalina/webresources/AbstractResourceSet.java
@@ -72,8 +72,8 @@ public abstract class AbstractResourceSet extends LifecycleBase implements WebRe
     public final void setWebAppMount(String webAppMount) {
         checkPath(webAppMount);
         // Optimise internal processing
-        if (webAppMount.equals("/")) {
-            this.webAppMount = "";
+        if (webAppMount.endsWith("/")) {
+            this.webAppMount = webAppMount.substring(0, webAppMount.length() - 1);
         } else {
             this.webAppMount = webAppMount;
         }

--- a/java/org/apache/coyote/RequestInfo.java
+++ b/java/org/apache/coyote/RequestInfo.java
@@ -261,4 +261,18 @@ public class RequestInfo {
     public void setLastRequestProcessingTime(long lastRequestProcessingTime) {
         this.lastRequestProcessingTime = lastRequestProcessingTime;
     }
+
+    public void recycleStatistcs() {
+        this.bytesSent = 0;
+        this.bytesReceived = 0;
+
+        this.processingTime = 0;
+        this.maxTime = 0;
+        this.maxRequestUri = null;
+
+        this.requestCount = 0;
+        this.errorCount = 0;
+
+        this.lastRequestProcessingTime = 0;
+    }
 }

--- a/java/org/apache/coyote/http2/StreamProcessor.java
+++ b/java/org/apache/coyote/http2/StreamProcessor.java
@@ -147,8 +147,14 @@ class StreamProcessor extends AbstractProcessor implements NonPipeliningProcesso
                     state = SocketState.CLOSED;
                 } finally {
                     if (state == SocketState.CLOSED) {
-                        stream.recycle();
+                        /*
+                         * Recycle this processor before the stream is recycled as recycling the stream will add the
+                         * request and the response to the pool for re-use (if re-use is enabled) and the request
+                         * statistics updating in StreamProcessor.recycle() needs to happen before the request and
+                         * response are added to the pool to avoid concurrency issues corrupting the statistics.
+                         */
                         recycle();
+                        stream.recycle();
                     }
                 }
             } finally {
@@ -415,6 +421,12 @@ class StreamProcessor extends AbstractProcessor implements NonPipeliningProcesso
         if (global != null) {
             global.removeRequestProcessor(request.getRequestProcessor());
         }
+
+        /*
+         * Clear the statistics ready for re-use of the request. If we don't clear the statistics, the statistics for
+         * the current request will be included in the statistics for all future requests.
+         */
+        request.getRequestProcessor().recycleStatistcs();
 
         // Clear fields that can be cleared to aid GC and trigger NPEs if this
         // is reused

--- a/java/org/apache/el/parser/AstIdentifier.java
+++ b/java/org/apache/el/parser/AstIdentifier.java
@@ -79,8 +79,8 @@ public final class AstIdentifier extends SimpleNode {
         ctx.setPropertyResolved(false);
         Object result;
         /*
-         * Putting the Boolean into the ELContext is part of a performance optimisation for ImportELResolver.
-         * When looking up "foo", the resolver can't differentiate between ${ foo } and ${ foo.bar }. This is important
+         * Putting the Boolean into the ELContext is part of a performance optimisation for ImportELResolver. When
+         * looking up "foo", the resolver can't differentiate between ${ foo } and ${ foo.bar }. This is important
          * because the expensive class lookup only needs to be performed in the later case. This flag tells the resolver
          * if the lookup can be skipped.
          */

--- a/java/org/apache/el/parser/AstValue.java
+++ b/java/org/apache/el/parser/AstValue.java
@@ -269,8 +269,8 @@ public final class AstValue extends SimpleNode {
 
         int paramCount = types.length;
 
-        if (m.isVarArgs() && paramCount > 1 && (src == null || paramCount > src.length) || !m.isVarArgs() &&
-            (src == null || src.length != paramCount)) {
+        if (m.isVarArgs() && paramCount > 1 && (src == null || paramCount > src.length) ||
+                !m.isVarArgs() && (src == null || src.length != paramCount)) {
             String srcCount = null;
             if (src != null) {
                 srcCount = Integer.toString(src.length);

--- a/java/org/apache/el/parser/ELParser.java
+++ b/java/org/apache/el/parser/ELParser.java
@@ -26,7 +26,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
         boolean jjtc000 = true;
         jjtree.openNodeScope(jjtn000);
         try {
-            label_1: while (true) {
+            label_1:
+            while (true) {
                 switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                     case LITERAL_EXPRESSION:
                     case START_DYNAMIC_EXPRESSION:
@@ -219,7 +220,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
      */
     final public void Semicolon() throws ParseException {
         Assignment();
-        label_2: while (true) {
+        label_2:
+        while (true) {
             switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                 case SEMICOLON: {
                     ;
@@ -292,7 +294,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 case MINUS:
                 case IDENTIFIER: {
                     Ternary();
-                    label_3: while (true) {
+                    label_3:
+                    while (true) {
                         if (jj_2_1(2)) {
                             ;
                         } else {
@@ -434,7 +437,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                     switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                         case IDENTIFIER: {
                             Identifier();
-                            label_4: while (true) {
+                            label_4:
+                            while (true) {
                                 switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                                     case COMMA: {
                                         ;
@@ -534,7 +538,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 }
             }
             jj_consume_token(RPAREN);
-            label_5: while (true) {
+            label_5:
+            while (true) {
                 switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                     case LPAREN: {
                         ;
@@ -584,7 +589,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
      */
     final public void Ternary() throws ParseException {
         Or();
-        label_6: while (true) {
+        label_6:
+        while (true) {
             switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                 case QUESTIONMARK: {
                     ;
@@ -737,7 +743,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 boolean jjtc001 = true;
                 jjtree.openNodeScope(jjtn001);
                 try {
-                    label_7: while (true) {
+                    label_7:
+                    while (true) {
                         switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                             case OR0: {
                                 jj_consume_token(OR0);
@@ -815,7 +822,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 boolean jjtc001 = true;
                 jjtree.openNodeScope(jjtn001);
                 try {
-                    label_8: while (true) {
+                    label_8:
+                    while (true) {
                         switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                             case AND0: {
                                 jj_consume_token(AND0);
@@ -886,7 +894,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
      */
     final public void Equality() throws ParseException {
         Compare();
-        label_9: while (true) {
+        label_9:
+        while (true) {
             switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                 case EQ0:
                 case EQ1:
@@ -1021,7 +1030,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
      */
     final public void Compare() throws ParseException {
         Concatenation();
-        label_10: while (true) {
+        label_10:
+        while (true) {
             switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                 case GT0:
                 case GT1:
@@ -1269,7 +1279,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
      */
     final public void Concatenation() throws ParseException {
         Math();
-        label_11: while (true) {
+        label_11:
+        while (true) {
             switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                 case CONCAT: {
                     ;
@@ -1324,7 +1335,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
      */
     final public void Math() throws ParseException {
         Multiplication();
-        label_12: while (true) {
+        label_12:
+        while (true) {
             switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                 case PLUS:
                 case MINUS: {
@@ -1429,7 +1441,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
      */
     final public void Multiplication() throws ParseException {
         Unary();
-        label_13: while (true) {
+        label_13:
+        while (true) {
             switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                 case MULT:
                 case DIV0:
@@ -1826,7 +1839,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
         jjtree.openNodeScope(jjtn001);
         try {
             ValuePrefix();
-            label_14: while (true) {
+            label_14:
+            while (true) {
                 switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                     case DOT:
                     case LBRACK: {
@@ -2019,7 +2033,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 case MINUS:
                 case IDENTIFIER: {
                     Expression();
-                    label_15: while (true) {
+                    label_15:
+                    while (true) {
                         switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                             case COMMA: {
                                 ;
@@ -2148,7 +2163,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 case MINUS:
                 case IDENTIFIER: {
                     Expression();
-                    label_16: while (true) {
+                    label_16:
+                    while (true) {
                         switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                             case COMMA: {
                                 ;
@@ -2223,7 +2239,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 case MINUS:
                 case IDENTIFIER: {
                     Expression();
-                    label_17: while (true) {
+                    label_17:
+                    while (true) {
                         switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                             case COMMA: {
                                 ;
@@ -2302,7 +2319,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 case MINUS:
                 case IDENTIFIER: {
                     MapEntry();
-                    label_18: while (true) {
+                    label_18:
+                    while (true) {
                         switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                             case COMMA: {
                                 ;
@@ -2443,7 +2461,8 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
             } else {
                 jjtn000.setLocalName(t0.image);
             }
-            label_19: while (true) {
+            label_19:
+            while (true) {
                 MethodParameters();
                 switch ((jj_ntk == -1) ? jj_ntk_f() : jj_ntk) {
                     case LPAREN: {

--- a/java/org/apache/el/parser/ELParser.java
+++ b/java/org/apache/el/parser/ELParser.java
@@ -4335,7 +4335,7 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
     /** Generate ParseException. */
     public ParseException generateParseException() {
         jj_expentries.clear();
-        boolean[] la1tokens = new boolean[62];
+        boolean[] la1tokens = new boolean[61];
         if (jj_kind >= 0) {
             la1tokens[jj_kind] = true;
             jj_kind = -1;
@@ -4352,7 +4352,7 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 }
             }
         }
-        for (int i = 0; i < 62; i++) {
+        for (int i = 0; i < 61; i++) {
             if (la1tokens[i]) {
                 jj_expentry = new int[1];
                 jj_expentry[0] = i;

--- a/java/org/apache/el/parser/ELParser.java
+++ b/java/org/apache/el/parser/ELParser.java
@@ -3537,9 +3537,9 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
     private boolean jj_3R_Multiplication_254_9_73() {
         Token xsp;
         xsp = jj_scanpos;
-        if (jj_scan_token(51)) {
+        if (jj_scan_token(50)) {
             jj_scanpos = xsp;
-            if (jj_scan_token(52)) {
+            if (jj_scan_token(51)) {
                 return true;
             }
         }
@@ -3552,9 +3552,9 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
     private boolean jj_3R_Multiplication_252_9_72() {
         Token xsp;
         xsp = jj_scanpos;
-        if (jj_scan_token(49)) {
+        if (jj_scan_token(48)) {
             jj_scanpos = xsp;
-            if (jj_scan_token(50)) {
+            if (jj_scan_token(49)) {
                 return true;
             }
         }
@@ -4056,11 +4056,11 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
     }
 
     private static void jj_la1_init_1() {
-        jj_la1_1 = new int[] { 0x0, 0x0, 0x0, 0x1008860, 0x1008860, 0x0, 0x1000000, 0x1000000, 0x1008860, 0x0, 0x10000,
-                0x10000, 0x600, 0x600, 0x600, 0x180, 0x180, 0x180, 0x1e, 0x6, 0x18, 0x1e, 0x1, 0x0, 0x0, 0x1, 0x0, 0x1,
-                0x200000, 0xc000, 0xc000, 0x1e2000, 0x60000, 0x180000, 0x1e2000, 0x60, 0x60, 0x8000, 0x1000860, 0x0,
-                0x1000000, 0x0, 0x0, 0x0, 0x1008860, 0x0, 0x1000000, 0x0, 0x0, 0x1008860, 0x0, 0x1008860, 0x0,
-                0x1008860, 0x0, 0x0, 0x0, 0x0, };
+        jj_la1_1 = new int[] { 0x0, 0x0, 0x0, 0x804860, 0x804860, 0x0, 0x800000, 0x800000, 0x804860, 0x0, 0x8000,
+                0x8000, 0x600, 0x600, 0x600, 0x180, 0x180, 0x180, 0x1e, 0x6, 0x18, 0x1e, 0x1, 0x0, 0x0, 0x1, 0x0, 0x1,
+                0x100000, 0x6000, 0x6000, 0xf1000, 0x30000, 0xc0000, 0xf1000, 0x60, 0x60, 0x4000, 0x800860, 0x0,
+                0x800000, 0x0, 0x0, 0x0, 0x804860, 0x0, 0x800000, 0x0, 0x0, 0x804860, 0x0, 0x804860, 0x0, 0x804860, 0x0,
+                0x0, 0x0, 0x0, };
     }
 
     final private JJCalls[] jj_2_rtns = new JJCalls[10];
@@ -4335,7 +4335,7 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
     /** Generate ParseException. */
     public ParseException generateParseException() {
         jj_expentries.clear();
-        boolean[] la1tokens = new boolean[61];
+        boolean[] la1tokens = new boolean[59];
         if (jj_kind >= 0) {
             la1tokens[jj_kind] = true;
             jj_kind = -1;
@@ -4352,7 +4352,7 @@ public class ELParser/* @bgen(jjtree) */ implements ELParserTreeConstants, ELPar
                 }
             }
         }
-        for (int i = 0; i < 61; i++) {
+        for (int i = 0; i < 59; i++) {
             if (la1tokens[i]) {
                 jj_expentry = new int[1];
                 jj_expentry[0] = i;

--- a/java/org/apache/el/parser/ELParser.jjt
+++ b/java/org/apache/el/parser/ELParser.jjt
@@ -148,7 +148,7 @@ void LambdaExpressionOrInvocation() #LambdaExpression : {}
 
 /*
  * Ternary
- * For '?:' '? :', then Or
+ * For '??' '?:' '? :', then Or
  */
 void Ternary() : {}
 {

--- a/java/org/apache/el/parser/ELParser.jjt
+++ b/java/org/apache/el/parser/ELParser.jjt
@@ -542,7 +542,6 @@ java.util.Deque<Integer> deque = new java.util.ArrayDeque<Integer>();
 |    < OR0 : "||" >
 |    < OR1 : "or" >
 |    < EMPTY : "empty" >
-|    < INSTANCEOF : "instanceof" >
 |    < MULT : "*" >
 |    < PLUS : "+" >
 |    < MINUS : "-" >
@@ -555,7 +554,6 @@ java.util.Deque<Integer> deque = new java.util.ArrayDeque<Integer>();
 |    < ASSIGN : "=" >
 |    < ARROW : "->" >
 |    < IDENTIFIER : <JAVALETTER> (<JAVALETTER>|<JAVADIGIT>)* >
-|    < FUNCTIONSUFFIX : (<IDENTIFIER>) >
 |    < #JAVALETTER:
         [
         "\u0024",

--- a/java/org/apache/el/parser/ELParser.jjt
+++ b/java/org/apache/el/parser/ELParser.jjt
@@ -554,9 +554,8 @@ java.util.Deque<Integer> deque = new java.util.ArrayDeque<Integer>();
 |    < CONCAT : "+=" >
 |    < ASSIGN : "=" >
 |    < ARROW : "->" >
-|    < IDENTIFIER : (<JAVALETTER>|<IMPL_OBJ_START>) (<JAVALETTER>|<JAVADIGIT>)* >
+|    < IDENTIFIER : <JAVALETTER> (<JAVALETTER>|<JAVADIGIT>)* >
 |    < FUNCTIONSUFFIX : (<IDENTIFIER>) >
-|    < #IMPL_OBJ_START: "#" >
 |    < #JAVALETTER:
         [
         "\u0024",

--- a/java/org/apache/el/parser/ELParserConstants.java
+++ b/java/org/apache/el/parser/ELParserConstants.java
@@ -116,13 +116,11 @@ public interface ELParserConstants {
     /** RegularExpression Id. */
     int FUNCTIONSUFFIX = 57;
     /** RegularExpression Id. */
-    int IMPL_OBJ_START = 58;
+    int JAVALETTER = 58;
     /** RegularExpression Id. */
-    int JAVALETTER = 59;
+    int JAVADIGIT = 59;
     /** RegularExpression Id. */
-    int JAVADIGIT = 60;
-    /** RegularExpression Id. */
-    int ILLEGAL_CHARACTER = 61;
+    int ILLEGAL_CHARACTER = 60;
 
     /** Lexical state. */
     int DEFAULT = 0;
@@ -138,7 +136,7 @@ public interface ELParserConstants {
             "\":\"", "\";\"", "\",\"", "\">\"", "\"gt\"", "\"<\"", "\"lt\"", "\">=\"", "\"ge\"", "\"<=\"", "\"le\"",
             "\"==\"", "\"eq\"", "\"!=\"", "\"ne\"", "\"!\"", "\"not\"", "\"&&\"", "\"and\"", "\"||\"", "\"or\"",
             "\"empty\"", "\"instanceof\"", "\"*\"", "\"+\"", "\"-\"", "\"?\"", "\"/\"", "\"div\"", "\"%\"", "\"mod\"",
-            "\"+=\"", "\"=\"", "\"->\"", "<IDENTIFIER>", "<FUNCTIONSUFFIX>", "\"#\"", "<JAVALETTER>", "<JAVADIGIT>",
+            "\"+=\"", "\"=\"", "\"->\"", "<IDENTIFIER>", "<FUNCTIONSUFFIX>", "<JAVALETTER>", "<JAVADIGIT>",
             "<ILLEGAL_CHARACTER>", };
 
 }

--- a/java/org/apache/el/parser/ELParserConstants.java
+++ b/java/org/apache/el/parser/ELParserConstants.java
@@ -88,39 +88,35 @@ public interface ELParserConstants {
     /** RegularExpression Id. */
     int EMPTY = 43;
     /** RegularExpression Id. */
-    int INSTANCEOF = 44;
+    int MULT = 44;
     /** RegularExpression Id. */
-    int MULT = 45;
+    int PLUS = 45;
     /** RegularExpression Id. */
-    int PLUS = 46;
+    int MINUS = 46;
     /** RegularExpression Id. */
-    int MINUS = 47;
+    int QUESTIONMARK = 47;
     /** RegularExpression Id. */
-    int QUESTIONMARK = 48;
+    int DIV0 = 48;
     /** RegularExpression Id. */
-    int DIV0 = 49;
+    int DIV1 = 49;
     /** RegularExpression Id. */
-    int DIV1 = 50;
+    int MOD0 = 50;
     /** RegularExpression Id. */
-    int MOD0 = 51;
+    int MOD1 = 51;
     /** RegularExpression Id. */
-    int MOD1 = 52;
+    int CONCAT = 52;
     /** RegularExpression Id. */
-    int CONCAT = 53;
+    int ASSIGN = 53;
     /** RegularExpression Id. */
-    int ASSIGN = 54;
+    int ARROW = 54;
     /** RegularExpression Id. */
-    int ARROW = 55;
+    int IDENTIFIER = 55;
     /** RegularExpression Id. */
-    int IDENTIFIER = 56;
+    int JAVALETTER = 56;
     /** RegularExpression Id. */
-    int FUNCTIONSUFFIX = 57;
+    int JAVADIGIT = 57;
     /** RegularExpression Id. */
-    int JAVALETTER = 58;
-    /** RegularExpression Id. */
-    int JAVADIGIT = 59;
-    /** RegularExpression Id. */
-    int ILLEGAL_CHARACTER = 60;
+    int ILLEGAL_CHARACTER = 58;
 
     /** Lexical state. */
     int DEFAULT = 0;
@@ -135,8 +131,7 @@ public interface ELParserConstants {
             "<STRING_LITERAL>", "\"true\"", "\"false\"", "\"null\"", "\".\"", "\"(\"", "\")\"", "\"[\"", "\"]\"",
             "\":\"", "\";\"", "\",\"", "\">\"", "\"gt\"", "\"<\"", "\"lt\"", "\">=\"", "\"ge\"", "\"<=\"", "\"le\"",
             "\"==\"", "\"eq\"", "\"!=\"", "\"ne\"", "\"!\"", "\"not\"", "\"&&\"", "\"and\"", "\"||\"", "\"or\"",
-            "\"empty\"", "\"instanceof\"", "\"*\"", "\"+\"", "\"-\"", "\"?\"", "\"/\"", "\"div\"", "\"%\"", "\"mod\"",
-            "\"+=\"", "\"=\"", "\"->\"", "<IDENTIFIER>", "<FUNCTIONSUFFIX>", "<JAVALETTER>", "<JAVADIGIT>",
-            "<ILLEGAL_CHARACTER>", };
+            "\"empty\"", "\"*\"", "\"+\"", "\"-\"", "\"?\"", "\"/\"", "\"div\"", "\"%\"", "\"mod\"", "\"+=\"", "\"=\"",
+            "\"->\"", "<IDENTIFIER>", "<JAVALETTER>", "<JAVADIGIT>", "<ILLEGAL_CHARACTER>", };
 
 }

--- a/java/org/apache/el/parser/ELParserTokenManager.java
+++ b/java/org/apache/el/parser/ELParserTokenManager.java
@@ -899,7 +899,7 @@ public class ELParserTokenManager implements ELParserConstants {
                                 {
                                     jjCheckNAddStates(18, 22);
                                 }
-                            } else if ((0x1800000000L & l) != 0L) {
+                            } else if (curChar == 36) {
                                 if (kind > 56) {
                                     kind = 56;
                                 }
@@ -1078,7 +1078,7 @@ public class ELParserTokenManager implements ELParserConstants {
                         }
                             break;
                         case 27:
-                            if ((0x1800000000L & l) == 0L) {
+                            if (curChar != 36) {
                                 break;
                             }
                             if (kind > 56) {
@@ -1784,7 +1784,7 @@ public class ELParserTokenManager implements ELParserConstants {
                                 {
                                     jjCheckNAddStates(18, 22);
                                 }
-                            } else if ((0x1800000000L & l) != 0L) {
+                            } else if (curChar == 36) {
                                 if (kind > 56) {
                                     kind = 56;
                                 }
@@ -1963,7 +1963,7 @@ public class ELParserTokenManager implements ELParserConstants {
                         }
                             break;
                         case 27:
-                            if ((0x1800000000L & l) == 0L) {
+                            if (curChar != 36) {
                                 break;
                             }
                             if (kind > 56) {
@@ -2196,7 +2196,7 @@ public class ELParserTokenManager implements ELParserConstants {
             "\147\145", "\74\75", "\154\145", "\75\75", "\145\161", "\41\75", "\156\145", "\41", "\156\157\164",
             "\46\46", "\141\156\144", "\174\174", "\157\162", "\145\155\160\164\171",
             "\151\156\163\164\141\156\143\145\157\146", "\52", "\53", "\55", "\77", "\57", "\144\151\166", "\45",
-            "\155\157\144", "\53\75", "\75", "\55\76", null, null, null, null, null, null, };
+            "\155\157\144", "\53\75", "\75", "\55\76", null, null, null, null, null, };
 
     protected Token jjFillToken() {
         final Token t;
@@ -2497,8 +2497,8 @@ public class ELParserTokenManager implements ELParserConstants {
                     jjmatchedKind = 0x7fffffff;
                     jjmatchedPos = 0;
                     curPos = jjMoveStringLiteralDfa0_1();
-                    if (jjmatchedPos == 0 && jjmatchedKind > 61) {
-                        jjmatchedKind = 61;
+                    if (jjmatchedPos == 0 && jjmatchedKind > 60) {
+                        jjmatchedKind = 60;
                     }
                     break;
                 case 2:
@@ -2513,8 +2513,8 @@ public class ELParserTokenManager implements ELParserConstants {
                     jjmatchedKind = 0x7fffffff;
                     jjmatchedPos = 0;
                     curPos = jjMoveStringLiteralDfa0_2();
-                    if (jjmatchedPos == 0 && jjmatchedKind > 61) {
-                        jjmatchedKind = 61;
+                    if (jjmatchedPos == 0 && jjmatchedKind > 60) {
+                        jjmatchedKind = 60;
                     }
                     break;
             }
@@ -2688,8 +2688,8 @@ public class ELParserTokenManager implements ELParserConstants {
     /** Lex State array. */
     public static final int[] jjnewLexState = { -1, -1, 1, 1, -1, -1, -1, -1, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, };
-    static final long[] jjtoToken = { 0x23ffffffffffef0fL, };
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, };
+    static final long[] jjtoToken = { 0x13ffffffffffef0fL, };
     static final long[] jjtoSkip = { 0xf0L, };
     static final long[] jjtoSpecial = { 0x0L, };
     static final long[] jjtoMore = { 0x0L, };

--- a/java/org/apache/el/parser/ELParserTokenManager.java
+++ b/java/org/apache/el/parser/ELParserTokenManager.java
@@ -2465,7 +2465,8 @@ public class ELParserTokenManager implements ELParserConstants {
         Token matchedToken;
         int curPos = 0;
 
-        EOFLoop: for (;;) {
+        EOFLoop:
+        for (;;) {
             try {
                 curChar = input_stream.BeginToken();
             } catch (Exception e) {

--- a/java/org/apache/el/parser/ELParserTokenManager.java
+++ b/java/org/apache/el/parser/ELParserTokenManager.java
@@ -301,77 +301,39 @@ public class ELParserTokenManager implements ELParserConstants {
                 if ((active0 & 0x20000L) != 0L) {
                     return 1;
                 }
-                if ((active0 & 0x141d555401c000L) != 0L) {
-                    jjmatchedKind = 56;
-                    return 30;
+                if ((active0 & 0xa0d555401c000L) != 0L) {
+                    jjmatchedKind = 55;
+                    return 16;
                 }
                 return -1;
             case 1:
-                if ((active0 & 0x41554000000L) != 0L) {
-                    return 30;
-                }
-                if ((active0 & 0x1419400001c000L) != 0L) {
-                    jjmatchedKind = 56;
+                if ((active0 & 0xa09400001c000L) != 0L) {
+                    jjmatchedKind = 55;
                     jjmatchedPos = 1;
-                    return 30;
+                    return 16;
+                }
+                if ((active0 & 0x41554000000L) != 0L) {
+                    return 16;
                 }
                 return -1;
             case 2:
-                if ((active0 & 0x14014000000000L) != 0L) {
-                    return 30;
+                if ((active0 & 0xa014000000000L) != 0L) {
+                    return 16;
                 }
-                if ((active0 & 0x18000001c000L) != 0L) {
-                    jjmatchedKind = 56;
+                if ((active0 & 0x8000001c000L) != 0L) {
+                    jjmatchedKind = 55;
                     jjmatchedPos = 2;
-                    return 30;
+                    return 16;
                 }
                 return -1;
             case 3:
                 if ((active0 & 0x14000L) != 0L) {
-                    return 30;
+                    return 16;
                 }
-                if ((active0 & 0x180000008000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 3;
-                    return 30;
-                }
-                return -1;
-            case 4:
                 if ((active0 & 0x80000008000L) != 0L) {
-                    return 30;
-                }
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 4;
-                    return 30;
-                }
-                return -1;
-            case 5:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 5;
-                    return 30;
-                }
-                return -1;
-            case 6:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 6;
-                    return 30;
-                }
-                return -1;
-            case 7:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 7;
-                    return 30;
-                }
-                return -1;
-            case 8:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 8;
-                    return 30;
+                    jjmatchedKind = 55;
+                    jjmatchedPos = 3;
+                    return 16;
                 }
                 return -1;
             default:
@@ -389,7 +351,7 @@ public class ELParserTokenManager implements ELParserConstants {
                 jjmatchedKind = 37;
                 return jjMoveStringLiteralDfa1_2(0x800000000L);
             case 37:
-                return jjStopAtPos(0, 51);
+                return jjStopAtPos(0, 50);
             case 38:
                 return jjMoveStringLiteralDfa1_2(0x8000000000L);
             case 40:
@@ -397,19 +359,19 @@ public class ELParserTokenManager implements ELParserConstants {
             case 41:
                 return jjStopAtPos(0, 19);
             case 42:
-                return jjStopAtPos(0, 45);
+                return jjStopAtPos(0, 44);
             case 43:
-                jjmatchedKind = 46;
-                return jjMoveStringLiteralDfa1_2(0x20000000000000L);
+                jjmatchedKind = 45;
+                return jjMoveStringLiteralDfa1_2(0x10000000000000L);
             case 44:
                 return jjStopAtPos(0, 24);
             case 45:
-                jjmatchedKind = 47;
-                return jjMoveStringLiteralDfa1_2(0x80000000000000L);
+                jjmatchedKind = 46;
+                return jjMoveStringLiteralDfa1_2(0x40000000000000L);
             case 46:
                 return jjStartNfaWithStates_2(0, 17, 1);
             case 47:
-                return jjStopAtPos(0, 49);
+                return jjStopAtPos(0, 48);
             case 58:
                 return jjStopAtPos(0, 22);
             case 59:
@@ -418,13 +380,13 @@ public class ELParserTokenManager implements ELParserConstants {
                 jjmatchedKind = 27;
                 return jjMoveStringLiteralDfa1_2(0x80000000L);
             case 61:
-                jjmatchedKind = 54;
+                jjmatchedKind = 53;
                 return jjMoveStringLiteralDfa1_2(0x200000000L);
             case 62:
                 jjmatchedKind = 25;
                 return jjMoveStringLiteralDfa1_2(0x20000000L);
             case 63:
-                return jjStopAtPos(0, 48);
+                return jjStopAtPos(0, 47);
             case 91:
                 return jjStopAtPos(0, 20);
             case 93:
@@ -432,19 +394,17 @@ public class ELParserTokenManager implements ELParserConstants {
             case 97:
                 return jjMoveStringLiteralDfa1_2(0x10000000000L);
             case 100:
-                return jjMoveStringLiteralDfa1_2(0x4000000000000L);
+                return jjMoveStringLiteralDfa1_2(0x2000000000000L);
             case 101:
                 return jjMoveStringLiteralDfa1_2(0x80400000000L);
             case 102:
                 return jjMoveStringLiteralDfa1_2(0x8000L);
             case 103:
                 return jjMoveStringLiteralDfa1_2(0x44000000L);
-            case 105:
-                return jjMoveStringLiteralDfa1_2(0x100000000000L);
             case 108:
                 return jjMoveStringLiteralDfa1_2(0x110000000L);
             case 109:
-                return jjMoveStringLiteralDfa1_2(0x10000000000000L);
+                return jjMoveStringLiteralDfa1_2(0x8000000000000L);
             case 110:
                 return jjMoveStringLiteralDfa1_2(0x5000010000L);
             case 111:
@@ -484,49 +444,49 @@ public class ELParserTokenManager implements ELParserConstants {
                     return jjStopAtPos(1, 33);
                 } else if ((active0 & 0x800000000L) != 0L) {
                     return jjStopAtPos(1, 35);
-                } else if ((active0 & 0x20000000000000L) != 0L) {
-                    return jjStopAtPos(1, 53);
+                } else if ((active0 & 0x10000000000000L) != 0L) {
+                    return jjStopAtPos(1, 52);
                 }
                 break;
             case 62:
-                if ((active0 & 0x80000000000000L) != 0L) {
-                    return jjStopAtPos(1, 55);
+                if ((active0 & 0x40000000000000L) != 0L) {
+                    return jjStopAtPos(1, 54);
                 }
                 break;
             case 97:
                 return jjMoveStringLiteralDfa2_2(active0, 0x8000L);
             case 101:
                 if ((active0 & 0x40000000L) != 0L) {
-                    return jjStartNfaWithStates_2(1, 30, 30);
+                    return jjStartNfaWithStates_2(1, 30, 16);
                 } else if ((active0 & 0x100000000L) != 0L) {
-                    return jjStartNfaWithStates_2(1, 32, 30);
+                    return jjStartNfaWithStates_2(1, 32, 16);
                 } else if ((active0 & 0x1000000000L) != 0L) {
-                    return jjStartNfaWithStates_2(1, 36, 30);
+                    return jjStartNfaWithStates_2(1, 36, 16);
                 }
                 break;
             case 105:
-                return jjMoveStringLiteralDfa2_2(active0, 0x4000000000000L);
+                return jjMoveStringLiteralDfa2_2(active0, 0x2000000000000L);
             case 109:
                 return jjMoveStringLiteralDfa2_2(active0, 0x80000000000L);
             case 110:
-                return jjMoveStringLiteralDfa2_2(active0, 0x110000000000L);
+                return jjMoveStringLiteralDfa2_2(active0, 0x10000000000L);
             case 111:
-                return jjMoveStringLiteralDfa2_2(active0, 0x10004000000000L);
+                return jjMoveStringLiteralDfa2_2(active0, 0x8004000000000L);
             case 113:
                 if ((active0 & 0x400000000L) != 0L) {
-                    return jjStartNfaWithStates_2(1, 34, 30);
+                    return jjStartNfaWithStates_2(1, 34, 16);
                 }
                 break;
             case 114:
                 if ((active0 & 0x40000000000L) != 0L) {
-                    return jjStartNfaWithStates_2(1, 42, 30);
+                    return jjStartNfaWithStates_2(1, 42, 16);
                 }
                 return jjMoveStringLiteralDfa2_2(active0, 0x4000L);
             case 116:
                 if ((active0 & 0x4000000L) != 0L) {
-                    return jjStartNfaWithStates_2(1, 26, 30);
+                    return jjStartNfaWithStates_2(1, 26, 16);
                 } else if ((active0 & 0x10000000L) != 0L) {
-                    return jjStartNfaWithStates_2(1, 28, 30);
+                    return jjStartNfaWithStates_2(1, 28, 16);
                 }
                 break;
             case 117:
@@ -555,27 +515,25 @@ public class ELParserTokenManager implements ELParserConstants {
         switch (curChar) {
             case 100:
                 if ((active0 & 0x10000000000L) != 0L) {
-                    return jjStartNfaWithStates_2(2, 40, 30);
-                } else if ((active0 & 0x10000000000000L) != 0L) {
-                    return jjStartNfaWithStates_2(2, 52, 30);
+                    return jjStartNfaWithStates_2(2, 40, 16);
+                } else if ((active0 & 0x8000000000000L) != 0L) {
+                    return jjStartNfaWithStates_2(2, 51, 16);
                 }
                 break;
             case 108:
                 return jjMoveStringLiteralDfa3_2(active0, 0x18000L);
             case 112:
                 return jjMoveStringLiteralDfa3_2(active0, 0x80000000000L);
-            case 115:
-                return jjMoveStringLiteralDfa3_2(active0, 0x100000000000L);
             case 116:
                 if ((active0 & 0x4000000000L) != 0L) {
-                    return jjStartNfaWithStates_2(2, 38, 30);
+                    return jjStartNfaWithStates_2(2, 38, 16);
                 }
                 break;
             case 117:
                 return jjMoveStringLiteralDfa3_2(active0, 0x4000L);
             case 118:
-                if ((active0 & 0x4000000000000L) != 0L) {
-                    return jjStartNfaWithStates_2(2, 50, 30);
+                if ((active0 & 0x2000000000000L) != 0L) {
+                    return jjStartNfaWithStates_2(2, 49, 16);
                 }
                 break;
             default:
@@ -597,18 +555,18 @@ public class ELParserTokenManager implements ELParserConstants {
         switch (curChar) {
             case 101:
                 if ((active0 & 0x4000L) != 0L) {
-                    return jjStartNfaWithStates_2(3, 14, 30);
+                    return jjStartNfaWithStates_2(3, 14, 16);
                 }
                 break;
             case 108:
                 if ((active0 & 0x10000L) != 0L) {
-                    return jjStartNfaWithStates_2(3, 16, 30);
+                    return jjStartNfaWithStates_2(3, 16, 16);
                 }
                 break;
             case 115:
                 return jjMoveStringLiteralDfa4_2(active0, 0x8000L);
             case 116:
-                return jjMoveStringLiteralDfa4_2(active0, 0x180000000000L);
+                return jjMoveStringLiteralDfa4_2(active0, 0x80000000000L);
             default:
                 break;
         }
@@ -626,120 +584,20 @@ public class ELParserTokenManager implements ELParserConstants {
             return 4;
         }
         switch (curChar) {
-            case 97:
-                return jjMoveStringLiteralDfa5_2(active0, 0x100000000000L);
             case 101:
                 if ((active0 & 0x8000L) != 0L) {
-                    return jjStartNfaWithStates_2(4, 15, 30);
+                    return jjStartNfaWithStates_2(4, 15, 16);
                 }
                 break;
             case 121:
                 if ((active0 & 0x80000000000L) != 0L) {
-                    return jjStartNfaWithStates_2(4, 43, 30);
+                    return jjStartNfaWithStates_2(4, 43, 16);
                 }
                 break;
             default:
                 break;
         }
         return jjStartNfa_2(3, active0);
-    }
-
-    private int jjMoveStringLiteralDfa5_2(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_2(3, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_2(4, active0);
-            return 5;
-        }
-        switch (curChar) {
-            case 110:
-                return jjMoveStringLiteralDfa6_2(active0, 0x100000000000L);
-            default:
-                break;
-        }
-        return jjStartNfa_2(4, active0);
-    }
-
-    private int jjMoveStringLiteralDfa6_2(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_2(4, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_2(5, active0);
-            return 6;
-        }
-        switch (curChar) {
-            case 99:
-                return jjMoveStringLiteralDfa7_2(active0, 0x100000000000L);
-            default:
-                break;
-        }
-        return jjStartNfa_2(5, active0);
-    }
-
-    private int jjMoveStringLiteralDfa7_2(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_2(5, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_2(6, active0);
-            return 7;
-        }
-        switch (curChar) {
-            case 101:
-                return jjMoveStringLiteralDfa8_2(active0, 0x100000000000L);
-            default:
-                break;
-        }
-        return jjStartNfa_2(6, active0);
-    }
-
-    private int jjMoveStringLiteralDfa8_2(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_2(6, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_2(7, active0);
-            return 8;
-        }
-        switch (curChar) {
-            case 111:
-                return jjMoveStringLiteralDfa9_2(active0, 0x100000000000L);
-            default:
-                break;
-        }
-        return jjStartNfa_2(7, active0);
-    }
-
-    private int jjMoveStringLiteralDfa9_2(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_2(7, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_2(8, active0);
-            return 9;
-        }
-        switch (curChar) {
-            case 102:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    return jjStartNfaWithStates_2(9, 44, 30);
-                }
-                break;
-            default:
-                break;
-        }
-        return jjStartNfa_2(8, active0);
     }
 
     private int jjStartNfaWithStates_2(int pos, int kind, int state) {
@@ -879,7 +737,7 @@ public class ELParserTokenManager implements ELParserConstants {
 
     private int jjMoveNfa_2(int startState, int curPos) {
         int startsAt = 0;
-        jjnewStateCnt = 30;
+        jjnewStateCnt = 29;
         int i = 1;
         jjstateSet[0] = startState;
         int kind = 0x7fffffff;
@@ -900,11 +758,11 @@ public class ELParserTokenManager implements ELParserConstants {
                                     jjCheckNAddStates(18, 22);
                                 }
                             } else if (curChar == 36) {
-                                if (kind > 56) {
-                                    kind = 56;
+                                if (kind > 55) {
+                                    kind = 55;
                                 }
                                 {
-                                    jjCheckNAddTwoStates(28, 29);
+                                    jjCheckNAdd(16);
                                 }
                             } else if (curChar == 39) {
                                 jjCheckNAddStates(23, 25);
@@ -912,24 +770,6 @@ public class ELParserTokenManager implements ELParserConstants {
                                 jjCheckNAddStates(26, 28);
                             } else if (curChar == 46) {
                                 jjCheckNAdd(1);
-                            }
-                            break;
-                        case 30:
-                            if ((0x3ff00100fffc1ffL & l) != 0L) {
-                                if (kind > 57) {
-                                    kind = 57;
-                                }
-                                {
-                                    jjCheckNAdd(29);
-                                }
-                            }
-                            if ((0x3ff00100fffc1ffL & l) != 0L) {
-                                if (kind > 56) {
-                                    kind = 56;
-                                }
-                                {
-                                    jjCheckNAdd(28);
-                                }
                             }
                             break;
                         case 1:
@@ -998,6 +838,26 @@ public class ELParserTokenManager implements ELParserConstants {
                             }
                             break;
                         case 15:
+                            if (curChar != 36) {
+                                break;
+                            }
+                            if (kind > 55) {
+                                kind = 55;
+                            } {
+                            jjCheckNAdd(16);
+                        }
+                            break;
+                        case 16:
+                            if ((0x3ff00100fffc1ffL & l) == 0L) {
+                                break;
+                            }
+                            if (kind > 55) {
+                                kind = 55;
+                            } {
+                            jjCheckNAdd(16);
+                        }
+                            break;
+                        case 17:
                             if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
@@ -1007,104 +867,74 @@ public class ELParserTokenManager implements ELParserConstants {
                             jjCheckNAddStates(18, 22);
                         }
                             break;
-                        case 16:
+                        case 18:
                             if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
                             if (kind > 10) {
                                 kind = 10;
                             } {
-                            jjCheckNAdd(16);
+                            jjCheckNAdd(18);
                         }
                             break;
-                        case 17:
+                        case 19:
                             if ((0x3ff000000000000L & l) != 0L) {
-                                jjCheckNAddTwoStates(17, 18);
+                                jjCheckNAddTwoStates(19, 20);
                             }
                             break;
-                        case 18:
+                        case 20:
                             if (curChar != 46) {
                                 break;
                             }
                             if (kind > 11) {
                                 kind = 11;
                             } {
-                            jjCheckNAddTwoStates(19, 20);
-                        }
-                            break;
-                        case 19:
-                            if ((0x3ff000000000000L & l) == 0L) {
-                                break;
-                            }
-                            if (kind > 11) {
-                                kind = 11;
-                            } {
-                            jjCheckNAddTwoStates(19, 20);
+                            jjCheckNAddTwoStates(21, 22);
                         }
                             break;
                         case 21:
-                            if ((0x280000000000L & l) != 0L) {
-                                jjCheckNAdd(22);
-                            }
-                            break;
-                        case 22:
                             if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
                             if (kind > 11) {
                                 kind = 11;
                             } {
-                            jjCheckNAdd(22);
+                            jjCheckNAddTwoStates(21, 22);
                         }
                             break;
                         case 23:
-                            if ((0x3ff000000000000L & l) != 0L) {
-                                jjCheckNAddTwoStates(23, 24);
-                            }
-                            break;
-                        case 25:
                             if ((0x280000000000L & l) != 0L) {
-                                jjCheckNAdd(26);
+                                jjCheckNAdd(24);
                             }
                             break;
-                        case 26:
+                        case 24:
                             if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
                             if (kind > 11) {
                                 kind = 11;
                             } {
-                            jjCheckNAdd(26);
+                            jjCheckNAdd(24);
                         }
+                            break;
+                        case 25:
+                            if ((0x3ff000000000000L & l) != 0L) {
+                                jjCheckNAddTwoStates(25, 26);
+                            }
                             break;
                         case 27:
-                            if (curChar != 36) {
-                                break;
+                            if ((0x280000000000L & l) != 0L) {
+                                jjCheckNAdd(28);
                             }
-                            if (kind > 56) {
-                                kind = 56;
-                            } {
-                            jjCheckNAddTwoStates(28, 29);
-                        }
                             break;
                         case 28:
-                            if ((0x3ff00100fffc1ffL & l) == 0L) {
+                            if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
-                            if (kind > 56) {
-                                kind = 56;
+                            if (kind > 11) {
+                                kind = 11;
                             } {
                             jjCheckNAdd(28);
-                        }
-                            break;
-                        case 29:
-                            if ((0x3ff00100fffc1ffL & l) == 0L) {
-                                break;
-                            }
-                            if (kind > 57) {
-                                kind = 57;
-                            } {
-                            jjCheckNAdd(29);
                         }
                             break;
                         default:
@@ -1119,29 +949,11 @@ public class ELParserTokenManager implements ELParserConstants {
                             if ((0x7fffffe87fffffeL & l) == 0L) {
                                 break;
                             }
-                            if (kind > 56) {
-                                kind = 56;
+                            if (kind > 55) {
+                                kind = 55;
                             } {
-                            jjCheckNAddTwoStates(28, 29);
+                            jjCheckNAdd(16);
                         }
-                            break;
-                        case 30:
-                            if ((0x87fffffe87fffffeL & l) != 0L) {
-                                if (kind > 57) {
-                                    kind = 57;
-                                }
-                                {
-                                    jjCheckNAdd(29);
-                                }
-                            }
-                            if ((0x87fffffe87fffffeL & l) != 0L) {
-                                if (kind > 56) {
-                                    kind = 56;
-                                }
-                                {
-                                    jjCheckNAdd(28);
-                                }
-                            }
                             break;
                         case 2:
                             if ((0x2000000020L & l) != 0L) {
@@ -1178,35 +990,25 @@ public class ELParserTokenManager implements ELParserConstants {
                                 jjCheckNAddStates(23, 25);
                             }
                             break;
-                        case 20:
+                        case 16:
+                            if ((0x87fffffe87fffffeL & l) == 0L) {
+                                break;
+                            }
+                            if (kind > 55) {
+                                kind = 55;
+                            } {
+                            jjCheckNAdd(16);
+                        }
+                            break;
+                        case 22:
                             if ((0x2000000020L & l) != 0L) {
                                 jjAddStates(31, 32);
                             }
                             break;
-                        case 24:
+                        case 26:
                             if ((0x2000000020L & l) != 0L) {
                                 jjAddStates(33, 34);
                             }
-                            break;
-                        case 28:
-                            if ((0x87fffffe87fffffeL & l) == 0L) {
-                                break;
-                            }
-                            if (kind > 56) {
-                                kind = 56;
-                            } {
-                            jjCheckNAdd(28);
-                        }
-                            break;
-                        case 29:
-                            if ((0x87fffffe87fffffeL & l) == 0L) {
-                                break;
-                            }
-                            if (kind > 57) {
-                                kind = 57;
-                            } {
-                            jjCheckNAdd(29);
-                        }
                             break;
                         default:
                             break;
@@ -1224,29 +1026,11 @@ public class ELParserTokenManager implements ELParserConstants {
                             if (!jjCanMove_1(hiByte, i1, i2, l1, l2)) {
                                 break;
                             }
-                            if (kind > 56) {
-                                kind = 56;
+                            if (kind > 55) {
+                                kind = 55;
                             } {
-                            jjCheckNAddTwoStates(28, 29);
+                            jjCheckNAdd(16);
                         }
-                            break;
-                        case 30:
-                            if (jjCanMove_2(hiByte, i1, i2, l1, l2)) {
-                                if (kind > 56) {
-                                    kind = 56;
-                                }
-                                {
-                                    jjCheckNAdd(28);
-                                }
-                            }
-                            if (jjCanMove_2(hiByte, i1, i2, l1, l2)) {
-                                if (kind > 57) {
-                                    kind = 57;
-                                }
-                                {
-                                    jjCheckNAdd(29);
-                                }
-                            }
                             break;
                         case 6:
                             if (jjCanMove_0(hiByte, i1, i2, l1, l2)) {
@@ -1258,24 +1042,14 @@ public class ELParserTokenManager implements ELParserConstants {
                                 jjAddStates(23, 25);
                             }
                             break;
-                        case 28:
+                        case 16:
                             if (!jjCanMove_2(hiByte, i1, i2, l1, l2)) {
                                 break;
                             }
-                            if (kind > 56) {
-                                kind = 56;
+                            if (kind > 55) {
+                                kind = 55;
                             } {
-                            jjCheckNAdd(28);
-                        }
-                            break;
-                        case 29:
-                            if (!jjCanMove_2(hiByte, i1, i2, l1, l2)) {
-                                break;
-                            }
-                            if (kind > 57) {
-                                kind = 57;
-                            } {
-                            jjCheckNAdd(29);
+                            jjCheckNAdd(16);
                         }
                             break;
                         default:
@@ -1293,7 +1067,7 @@ public class ELParserTokenManager implements ELParserConstants {
                 kind = 0x7fffffff;
             }
             ++curPos;
-            if ((i = jjnewStateCnt) == (startsAt = 30 - (jjnewStateCnt = startsAt))) {
+            if ((i = jjnewStateCnt) == (startsAt = 29 - (jjnewStateCnt = startsAt))) {
                 return curPos;
             }
             try {
@@ -1310,77 +1084,39 @@ public class ELParserTokenManager implements ELParserConstants {
                 if ((active0 & 0x20000L) != 0L) {
                     return 1;
                 }
-                if ((active0 & 0x141d555401c000L) != 0L) {
-                    jjmatchedKind = 56;
-                    return 30;
+                if ((active0 & 0xa0d555401c000L) != 0L) {
+                    jjmatchedKind = 55;
+                    return 16;
                 }
                 return -1;
             case 1:
-                if ((active0 & 0x41554000000L) != 0L) {
-                    return 30;
-                }
-                if ((active0 & 0x1419400001c000L) != 0L) {
-                    jjmatchedKind = 56;
+                if ((active0 & 0xa09400001c000L) != 0L) {
+                    jjmatchedKind = 55;
                     jjmatchedPos = 1;
-                    return 30;
+                    return 16;
+                }
+                if ((active0 & 0x41554000000L) != 0L) {
+                    return 16;
                 }
                 return -1;
             case 2:
-                if ((active0 & 0x14014000000000L) != 0L) {
-                    return 30;
+                if ((active0 & 0xa014000000000L) != 0L) {
+                    return 16;
                 }
-                if ((active0 & 0x18000001c000L) != 0L) {
-                    jjmatchedKind = 56;
+                if ((active0 & 0x8000001c000L) != 0L) {
+                    jjmatchedKind = 55;
                     jjmatchedPos = 2;
-                    return 30;
+                    return 16;
                 }
                 return -1;
             case 3:
                 if ((active0 & 0x14000L) != 0L) {
-                    return 30;
+                    return 16;
                 }
-                if ((active0 & 0x180000008000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 3;
-                    return 30;
-                }
-                return -1;
-            case 4:
                 if ((active0 & 0x80000008000L) != 0L) {
-                    return 30;
-                }
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 4;
-                    return 30;
-                }
-                return -1;
-            case 5:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 5;
-                    return 30;
-                }
-                return -1;
-            case 6:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 6;
-                    return 30;
-                }
-                return -1;
-            case 7:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 7;
-                    return 30;
-                }
-                return -1;
-            case 8:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    jjmatchedKind = 56;
-                    jjmatchedPos = 8;
-                    return 30;
+                    jjmatchedKind = 55;
+                    jjmatchedPos = 3;
+                    return 16;
                 }
                 return -1;
             default:
@@ -1398,7 +1134,7 @@ public class ELParserTokenManager implements ELParserConstants {
                 jjmatchedKind = 37;
                 return jjMoveStringLiteralDfa1_1(0x800000000L);
             case 37:
-                return jjStopAtPos(0, 51);
+                return jjStopAtPos(0, 50);
             case 38:
                 return jjMoveStringLiteralDfa1_1(0x8000000000L);
             case 40:
@@ -1406,19 +1142,19 @@ public class ELParserTokenManager implements ELParserConstants {
             case 41:
                 return jjStopAtPos(0, 19);
             case 42:
-                return jjStopAtPos(0, 45);
+                return jjStopAtPos(0, 44);
             case 43:
-                jjmatchedKind = 46;
-                return jjMoveStringLiteralDfa1_1(0x20000000000000L);
+                jjmatchedKind = 45;
+                return jjMoveStringLiteralDfa1_1(0x10000000000000L);
             case 44:
                 return jjStopAtPos(0, 24);
             case 45:
-                jjmatchedKind = 47;
-                return jjMoveStringLiteralDfa1_1(0x80000000000000L);
+                jjmatchedKind = 46;
+                return jjMoveStringLiteralDfa1_1(0x40000000000000L);
             case 46:
                 return jjStartNfaWithStates_1(0, 17, 1);
             case 47:
-                return jjStopAtPos(0, 49);
+                return jjStopAtPos(0, 48);
             case 58:
                 return jjStopAtPos(0, 22);
             case 59:
@@ -1427,13 +1163,13 @@ public class ELParserTokenManager implements ELParserConstants {
                 jjmatchedKind = 27;
                 return jjMoveStringLiteralDfa1_1(0x80000000L);
             case 61:
-                jjmatchedKind = 54;
+                jjmatchedKind = 53;
                 return jjMoveStringLiteralDfa1_1(0x200000000L);
             case 62:
                 jjmatchedKind = 25;
                 return jjMoveStringLiteralDfa1_1(0x20000000L);
             case 63:
-                return jjStopAtPos(0, 48);
+                return jjStopAtPos(0, 47);
             case 91:
                 return jjStopAtPos(0, 20);
             case 93:
@@ -1441,19 +1177,17 @@ public class ELParserTokenManager implements ELParserConstants {
             case 97:
                 return jjMoveStringLiteralDfa1_1(0x10000000000L);
             case 100:
-                return jjMoveStringLiteralDfa1_1(0x4000000000000L);
+                return jjMoveStringLiteralDfa1_1(0x2000000000000L);
             case 101:
                 return jjMoveStringLiteralDfa1_1(0x80400000000L);
             case 102:
                 return jjMoveStringLiteralDfa1_1(0x8000L);
             case 103:
                 return jjMoveStringLiteralDfa1_1(0x44000000L);
-            case 105:
-                return jjMoveStringLiteralDfa1_1(0x100000000000L);
             case 108:
                 return jjMoveStringLiteralDfa1_1(0x110000000L);
             case 109:
-                return jjMoveStringLiteralDfa1_1(0x10000000000000L);
+                return jjMoveStringLiteralDfa1_1(0x8000000000000L);
             case 110:
                 return jjMoveStringLiteralDfa1_1(0x5000010000L);
             case 111:
@@ -1493,49 +1227,49 @@ public class ELParserTokenManager implements ELParserConstants {
                     return jjStopAtPos(1, 33);
                 } else if ((active0 & 0x800000000L) != 0L) {
                     return jjStopAtPos(1, 35);
-                } else if ((active0 & 0x20000000000000L) != 0L) {
-                    return jjStopAtPos(1, 53);
+                } else if ((active0 & 0x10000000000000L) != 0L) {
+                    return jjStopAtPos(1, 52);
                 }
                 break;
             case 62:
-                if ((active0 & 0x80000000000000L) != 0L) {
-                    return jjStopAtPos(1, 55);
+                if ((active0 & 0x40000000000000L) != 0L) {
+                    return jjStopAtPos(1, 54);
                 }
                 break;
             case 97:
                 return jjMoveStringLiteralDfa2_1(active0, 0x8000L);
             case 101:
                 if ((active0 & 0x40000000L) != 0L) {
-                    return jjStartNfaWithStates_1(1, 30, 30);
+                    return jjStartNfaWithStates_1(1, 30, 16);
                 } else if ((active0 & 0x100000000L) != 0L) {
-                    return jjStartNfaWithStates_1(1, 32, 30);
+                    return jjStartNfaWithStates_1(1, 32, 16);
                 } else if ((active0 & 0x1000000000L) != 0L) {
-                    return jjStartNfaWithStates_1(1, 36, 30);
+                    return jjStartNfaWithStates_1(1, 36, 16);
                 }
                 break;
             case 105:
-                return jjMoveStringLiteralDfa2_1(active0, 0x4000000000000L);
+                return jjMoveStringLiteralDfa2_1(active0, 0x2000000000000L);
             case 109:
                 return jjMoveStringLiteralDfa2_1(active0, 0x80000000000L);
             case 110:
-                return jjMoveStringLiteralDfa2_1(active0, 0x110000000000L);
+                return jjMoveStringLiteralDfa2_1(active0, 0x10000000000L);
             case 111:
-                return jjMoveStringLiteralDfa2_1(active0, 0x10004000000000L);
+                return jjMoveStringLiteralDfa2_1(active0, 0x8004000000000L);
             case 113:
                 if ((active0 & 0x400000000L) != 0L) {
-                    return jjStartNfaWithStates_1(1, 34, 30);
+                    return jjStartNfaWithStates_1(1, 34, 16);
                 }
                 break;
             case 114:
                 if ((active0 & 0x40000000000L) != 0L) {
-                    return jjStartNfaWithStates_1(1, 42, 30);
+                    return jjStartNfaWithStates_1(1, 42, 16);
                 }
                 return jjMoveStringLiteralDfa2_1(active0, 0x4000L);
             case 116:
                 if ((active0 & 0x4000000L) != 0L) {
-                    return jjStartNfaWithStates_1(1, 26, 30);
+                    return jjStartNfaWithStates_1(1, 26, 16);
                 } else if ((active0 & 0x10000000L) != 0L) {
-                    return jjStartNfaWithStates_1(1, 28, 30);
+                    return jjStartNfaWithStates_1(1, 28, 16);
                 }
                 break;
             case 117:
@@ -1564,27 +1298,25 @@ public class ELParserTokenManager implements ELParserConstants {
         switch (curChar) {
             case 100:
                 if ((active0 & 0x10000000000L) != 0L) {
-                    return jjStartNfaWithStates_1(2, 40, 30);
-                } else if ((active0 & 0x10000000000000L) != 0L) {
-                    return jjStartNfaWithStates_1(2, 52, 30);
+                    return jjStartNfaWithStates_1(2, 40, 16);
+                } else if ((active0 & 0x8000000000000L) != 0L) {
+                    return jjStartNfaWithStates_1(2, 51, 16);
                 }
                 break;
             case 108:
                 return jjMoveStringLiteralDfa3_1(active0, 0x18000L);
             case 112:
                 return jjMoveStringLiteralDfa3_1(active0, 0x80000000000L);
-            case 115:
-                return jjMoveStringLiteralDfa3_1(active0, 0x100000000000L);
             case 116:
                 if ((active0 & 0x4000000000L) != 0L) {
-                    return jjStartNfaWithStates_1(2, 38, 30);
+                    return jjStartNfaWithStates_1(2, 38, 16);
                 }
                 break;
             case 117:
                 return jjMoveStringLiteralDfa3_1(active0, 0x4000L);
             case 118:
-                if ((active0 & 0x4000000000000L) != 0L) {
-                    return jjStartNfaWithStates_1(2, 50, 30);
+                if ((active0 & 0x2000000000000L) != 0L) {
+                    return jjStartNfaWithStates_1(2, 49, 16);
                 }
                 break;
             default:
@@ -1606,18 +1338,18 @@ public class ELParserTokenManager implements ELParserConstants {
         switch (curChar) {
             case 101:
                 if ((active0 & 0x4000L) != 0L) {
-                    return jjStartNfaWithStates_1(3, 14, 30);
+                    return jjStartNfaWithStates_1(3, 14, 16);
                 }
                 break;
             case 108:
                 if ((active0 & 0x10000L) != 0L) {
-                    return jjStartNfaWithStates_1(3, 16, 30);
+                    return jjStartNfaWithStates_1(3, 16, 16);
                 }
                 break;
             case 115:
                 return jjMoveStringLiteralDfa4_1(active0, 0x8000L);
             case 116:
-                return jjMoveStringLiteralDfa4_1(active0, 0x180000000000L);
+                return jjMoveStringLiteralDfa4_1(active0, 0x80000000000L);
             default:
                 break;
         }
@@ -1635,120 +1367,20 @@ public class ELParserTokenManager implements ELParserConstants {
             return 4;
         }
         switch (curChar) {
-            case 97:
-                return jjMoveStringLiteralDfa5_1(active0, 0x100000000000L);
             case 101:
                 if ((active0 & 0x8000L) != 0L) {
-                    return jjStartNfaWithStates_1(4, 15, 30);
+                    return jjStartNfaWithStates_1(4, 15, 16);
                 }
                 break;
             case 121:
                 if ((active0 & 0x80000000000L) != 0L) {
-                    return jjStartNfaWithStates_1(4, 43, 30);
+                    return jjStartNfaWithStates_1(4, 43, 16);
                 }
                 break;
             default:
                 break;
         }
         return jjStartNfa_1(3, active0);
-    }
-
-    private int jjMoveStringLiteralDfa5_1(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_1(3, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_1(4, active0);
-            return 5;
-        }
-        switch (curChar) {
-            case 110:
-                return jjMoveStringLiteralDfa6_1(active0, 0x100000000000L);
-            default:
-                break;
-        }
-        return jjStartNfa_1(4, active0);
-    }
-
-    private int jjMoveStringLiteralDfa6_1(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_1(4, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_1(5, active0);
-            return 6;
-        }
-        switch (curChar) {
-            case 99:
-                return jjMoveStringLiteralDfa7_1(active0, 0x100000000000L);
-            default:
-                break;
-        }
-        return jjStartNfa_1(5, active0);
-    }
-
-    private int jjMoveStringLiteralDfa7_1(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_1(5, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_1(6, active0);
-            return 7;
-        }
-        switch (curChar) {
-            case 101:
-                return jjMoveStringLiteralDfa8_1(active0, 0x100000000000L);
-            default:
-                break;
-        }
-        return jjStartNfa_1(6, active0);
-    }
-
-    private int jjMoveStringLiteralDfa8_1(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_1(6, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_1(7, active0);
-            return 8;
-        }
-        switch (curChar) {
-            case 111:
-                return jjMoveStringLiteralDfa9_1(active0, 0x100000000000L);
-            default:
-                break;
-        }
-        return jjStartNfa_1(7, active0);
-    }
-
-    private int jjMoveStringLiteralDfa9_1(long old0, long active0) {
-        if (((active0 &= old0)) == 0L) {
-            return jjStartNfa_1(7, old0);
-        }
-        try {
-            curChar = input_stream.readChar();
-        } catch (java.io.IOException e) {
-            jjStopStringLiteralDfa_1(8, active0);
-            return 9;
-        }
-        switch (curChar) {
-            case 102:
-                if ((active0 & 0x100000000000L) != 0L) {
-                    return jjStartNfaWithStates_1(9, 44, 30);
-                }
-                break;
-            default:
-                break;
-        }
-        return jjStartNfa_1(8, active0);
     }
 
     private int jjStartNfaWithStates_1(int pos, int kind, int state) {
@@ -1764,7 +1396,7 @@ public class ELParserTokenManager implements ELParserConstants {
 
     private int jjMoveNfa_1(int startState, int curPos) {
         int startsAt = 0;
-        jjnewStateCnt = 30;
+        jjnewStateCnt = 29;
         int i = 1;
         jjstateSet[0] = startState;
         int kind = 0x7fffffff;
@@ -1785,11 +1417,11 @@ public class ELParserTokenManager implements ELParserConstants {
                                     jjCheckNAddStates(18, 22);
                                 }
                             } else if (curChar == 36) {
-                                if (kind > 56) {
-                                    kind = 56;
+                                if (kind > 55) {
+                                    kind = 55;
                                 }
                                 {
-                                    jjCheckNAddTwoStates(28, 29);
+                                    jjCheckNAdd(16);
                                 }
                             } else if (curChar == 39) {
                                 jjCheckNAddStates(23, 25);
@@ -1797,24 +1429,6 @@ public class ELParserTokenManager implements ELParserConstants {
                                 jjCheckNAddStates(26, 28);
                             } else if (curChar == 46) {
                                 jjCheckNAdd(1);
-                            }
-                            break;
-                        case 30:
-                            if ((0x3ff00100fffc1ffL & l) != 0L) {
-                                if (kind > 57) {
-                                    kind = 57;
-                                }
-                                {
-                                    jjCheckNAdd(29);
-                                }
-                            }
-                            if ((0x3ff00100fffc1ffL & l) != 0L) {
-                                if (kind > 56) {
-                                    kind = 56;
-                                }
-                                {
-                                    jjCheckNAdd(28);
-                                }
                             }
                             break;
                         case 1:
@@ -1883,6 +1497,26 @@ public class ELParserTokenManager implements ELParserConstants {
                             }
                             break;
                         case 15:
+                            if (curChar != 36) {
+                                break;
+                            }
+                            if (kind > 55) {
+                                kind = 55;
+                            } {
+                            jjCheckNAdd(16);
+                        }
+                            break;
+                        case 16:
+                            if ((0x3ff00100fffc1ffL & l) == 0L) {
+                                break;
+                            }
+                            if (kind > 55) {
+                                kind = 55;
+                            } {
+                            jjCheckNAdd(16);
+                        }
+                            break;
+                        case 17:
                             if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
@@ -1892,104 +1526,74 @@ public class ELParserTokenManager implements ELParserConstants {
                             jjCheckNAddStates(18, 22);
                         }
                             break;
-                        case 16:
+                        case 18:
                             if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
                             if (kind > 10) {
                                 kind = 10;
                             } {
-                            jjCheckNAdd(16);
+                            jjCheckNAdd(18);
                         }
                             break;
-                        case 17:
+                        case 19:
                             if ((0x3ff000000000000L & l) != 0L) {
-                                jjCheckNAddTwoStates(17, 18);
+                                jjCheckNAddTwoStates(19, 20);
                             }
                             break;
-                        case 18:
+                        case 20:
                             if (curChar != 46) {
                                 break;
                             }
                             if (kind > 11) {
                                 kind = 11;
                             } {
-                            jjCheckNAddTwoStates(19, 20);
-                        }
-                            break;
-                        case 19:
-                            if ((0x3ff000000000000L & l) == 0L) {
-                                break;
-                            }
-                            if (kind > 11) {
-                                kind = 11;
-                            } {
-                            jjCheckNAddTwoStates(19, 20);
+                            jjCheckNAddTwoStates(21, 22);
                         }
                             break;
                         case 21:
-                            if ((0x280000000000L & l) != 0L) {
-                                jjCheckNAdd(22);
-                            }
-                            break;
-                        case 22:
                             if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
                             if (kind > 11) {
                                 kind = 11;
                             } {
-                            jjCheckNAdd(22);
+                            jjCheckNAddTwoStates(21, 22);
                         }
                             break;
                         case 23:
-                            if ((0x3ff000000000000L & l) != 0L) {
-                                jjCheckNAddTwoStates(23, 24);
-                            }
-                            break;
-                        case 25:
                             if ((0x280000000000L & l) != 0L) {
-                                jjCheckNAdd(26);
+                                jjCheckNAdd(24);
                             }
                             break;
-                        case 26:
+                        case 24:
                             if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
                             if (kind > 11) {
                                 kind = 11;
                             } {
-                            jjCheckNAdd(26);
+                            jjCheckNAdd(24);
                         }
+                            break;
+                        case 25:
+                            if ((0x3ff000000000000L & l) != 0L) {
+                                jjCheckNAddTwoStates(25, 26);
+                            }
                             break;
                         case 27:
-                            if (curChar != 36) {
-                                break;
+                            if ((0x280000000000L & l) != 0L) {
+                                jjCheckNAdd(28);
                             }
-                            if (kind > 56) {
-                                kind = 56;
-                            } {
-                            jjCheckNAddTwoStates(28, 29);
-                        }
                             break;
                         case 28:
-                            if ((0x3ff00100fffc1ffL & l) == 0L) {
+                            if ((0x3ff000000000000L & l) == 0L) {
                                 break;
                             }
-                            if (kind > 56) {
-                                kind = 56;
+                            if (kind > 11) {
+                                kind = 11;
                             } {
                             jjCheckNAdd(28);
-                        }
-                            break;
-                        case 29:
-                            if ((0x3ff00100fffc1ffL & l) == 0L) {
-                                break;
-                            }
-                            if (kind > 57) {
-                                kind = 57;
-                            } {
-                            jjCheckNAdd(29);
                         }
                             break;
                         default:
@@ -2004,29 +1608,11 @@ public class ELParserTokenManager implements ELParserConstants {
                             if ((0x7fffffe87fffffeL & l) == 0L) {
                                 break;
                             }
-                            if (kind > 56) {
-                                kind = 56;
+                            if (kind > 55) {
+                                kind = 55;
                             } {
-                            jjCheckNAddTwoStates(28, 29);
+                            jjCheckNAdd(16);
                         }
-                            break;
-                        case 30:
-                            if ((0x87fffffe87fffffeL & l) != 0L) {
-                                if (kind > 57) {
-                                    kind = 57;
-                                }
-                                {
-                                    jjCheckNAdd(29);
-                                }
-                            }
-                            if ((0x87fffffe87fffffeL & l) != 0L) {
-                                if (kind > 56) {
-                                    kind = 56;
-                                }
-                                {
-                                    jjCheckNAdd(28);
-                                }
-                            }
                             break;
                         case 2:
                             if ((0x2000000020L & l) != 0L) {
@@ -2063,35 +1649,25 @@ public class ELParserTokenManager implements ELParserConstants {
                                 jjCheckNAddStates(23, 25);
                             }
                             break;
-                        case 20:
+                        case 16:
+                            if ((0x87fffffe87fffffeL & l) == 0L) {
+                                break;
+                            }
+                            if (kind > 55) {
+                                kind = 55;
+                            } {
+                            jjCheckNAdd(16);
+                        }
+                            break;
+                        case 22:
                             if ((0x2000000020L & l) != 0L) {
                                 jjAddStates(31, 32);
                             }
                             break;
-                        case 24:
+                        case 26:
                             if ((0x2000000020L & l) != 0L) {
                                 jjAddStates(33, 34);
                             }
-                            break;
-                        case 28:
-                            if ((0x87fffffe87fffffeL & l) == 0L) {
-                                break;
-                            }
-                            if (kind > 56) {
-                                kind = 56;
-                            } {
-                            jjCheckNAdd(28);
-                        }
-                            break;
-                        case 29:
-                            if ((0x87fffffe87fffffeL & l) == 0L) {
-                                break;
-                            }
-                            if (kind > 57) {
-                                kind = 57;
-                            } {
-                            jjCheckNAdd(29);
-                        }
                             break;
                         default:
                             break;
@@ -2109,29 +1685,11 @@ public class ELParserTokenManager implements ELParserConstants {
                             if (!jjCanMove_1(hiByte, i1, i2, l1, l2)) {
                                 break;
                             }
-                            if (kind > 56) {
-                                kind = 56;
+                            if (kind > 55) {
+                                kind = 55;
                             } {
-                            jjCheckNAddTwoStates(28, 29);
+                            jjCheckNAdd(16);
                         }
-                            break;
-                        case 30:
-                            if (jjCanMove_2(hiByte, i1, i2, l1, l2)) {
-                                if (kind > 56) {
-                                    kind = 56;
-                                }
-                                {
-                                    jjCheckNAdd(28);
-                                }
-                            }
-                            if (jjCanMove_2(hiByte, i1, i2, l1, l2)) {
-                                if (kind > 57) {
-                                    kind = 57;
-                                }
-                                {
-                                    jjCheckNAdd(29);
-                                }
-                            }
                             break;
                         case 6:
                             if (jjCanMove_0(hiByte, i1, i2, l1, l2)) {
@@ -2143,24 +1701,14 @@ public class ELParserTokenManager implements ELParserConstants {
                                 jjAddStates(23, 25);
                             }
                             break;
-                        case 28:
+                        case 16:
                             if (!jjCanMove_2(hiByte, i1, i2, l1, l2)) {
                                 break;
                             }
-                            if (kind > 56) {
-                                kind = 56;
+                            if (kind > 55) {
+                                kind = 55;
                             } {
-                            jjCheckNAdd(28);
-                        }
-                            break;
-                        case 29:
-                            if (!jjCanMove_2(hiByte, i1, i2, l1, l2)) {
-                                break;
-                            }
-                            if (kind > 57) {
-                                kind = 57;
-                            } {
-                            jjCheckNAdd(29);
+                            jjCheckNAdd(16);
                         }
                             break;
                         default:
@@ -2178,7 +1726,7 @@ public class ELParserTokenManager implements ELParserConstants {
                 kind = 0x7fffffff;
             }
             ++curPos;
-            if ((i = jjnewStateCnt) == (startsAt = 30 - (jjnewStateCnt = startsAt))) {
+            if ((i = jjnewStateCnt) == (startsAt = 29 - (jjnewStateCnt = startsAt))) {
                 return curPos;
             }
             try {
@@ -2194,9 +1742,8 @@ public class ELParserTokenManager implements ELParserConstants {
             "\175", null, null, null, null, "\164\162\165\145", "\146\141\154\163\145", "\156\165\154\154", "\56",
             "\50", "\51", "\133", "\135", "\72", "\73", "\54", "\76", "\147\164", "\74", "\154\164", "\76\75",
             "\147\145", "\74\75", "\154\145", "\75\75", "\145\161", "\41\75", "\156\145", "\41", "\156\157\164",
-            "\46\46", "\141\156\144", "\174\174", "\157\162", "\145\155\160\164\171",
-            "\151\156\163\164\141\156\143\145\157\146", "\52", "\53", "\55", "\77", "\57", "\144\151\166", "\45",
-            "\155\157\144", "\53\75", "\75", "\55\76", null, null, null, null, null, };
+            "\46\46", "\141\156\144", "\174\174", "\157\162", "\145\155\160\164\171", "\52", "\53", "\55", "\77", "\57",
+            "\144\151\166", "\45", "\155\157\144", "\53\75", "\75", "\55\76", null, null, null, null, };
 
     protected Token jjFillToken() {
         final Token t;
@@ -2221,8 +1768,8 @@ public class ELParserTokenManager implements ELParserConstants {
         return t;
     }
 
-    static final int[] jjnextStates = { 0, 1, 3, 4, 2, 0, 1, 4, 2, 0, 1, 4, 5, 2, 0, 1, 2, 6, 16, 17, 18, 23, 24, 11,
-            12, 14, 6, 7, 9, 3, 4, 21, 22, 25, 26, };
+    static final int[] jjnextStates = { 0, 1, 3, 4, 2, 0, 1, 4, 2, 0, 1, 4, 5, 2, 0, 1, 2, 6, 18, 19, 20, 25, 26, 11,
+            12, 14, 6, 7, 9, 3, 4, 23, 24, 27, 28, };
 
     private static final boolean jjCanMove_0(int hiByte, int i1, int i2, long l1, long l2) {
         switch (hiByte) {
@@ -2497,8 +2044,8 @@ public class ELParserTokenManager implements ELParserConstants {
                     jjmatchedKind = 0x7fffffff;
                     jjmatchedPos = 0;
                     curPos = jjMoveStringLiteralDfa0_1();
-                    if (jjmatchedPos == 0 && jjmatchedKind > 60) {
-                        jjmatchedKind = 60;
+                    if (jjmatchedPos == 0 && jjmatchedKind > 58) {
+                        jjmatchedKind = 58;
                     }
                     break;
                 case 2:
@@ -2513,8 +2060,8 @@ public class ELParserTokenManager implements ELParserConstants {
                     jjmatchedKind = 0x7fffffff;
                     jjmatchedPos = 0;
                     curPos = jjMoveStringLiteralDfa0_2();
-                    if (jjmatchedPos == 0 && jjmatchedKind > 60) {
-                        jjmatchedKind = 60;
+                    if (jjmatchedPos == 0 && jjmatchedKind > 58) {
+                        jjmatchedKind = 58;
                     }
                     break;
             }
@@ -2658,7 +2205,7 @@ public class ELParserTokenManager implements ELParserConstants {
     private void ReInitRounds() {
         int i;
         jjround = 0x80000001;
-        for (i = 30; i-- > 0;) {
+        for (i = 29; i-- > 0;) {
             jjrounds[i] = 0x80000000;
         }
     }
@@ -2688,15 +2235,15 @@ public class ELParserTokenManager implements ELParserConstants {
     /** Lex State array. */
     public static final int[] jjnewLexState = { -1, -1, 1, 1, -1, -1, -1, -1, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, };
-    static final long[] jjtoToken = { 0x13ffffffffffef0fL, };
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, };
+    static final long[] jjtoToken = { 0x4ffffffffffef0fL, };
     static final long[] jjtoSkip = { 0xf0L, };
     static final long[] jjtoSpecial = { 0x0L, };
     static final long[] jjtoMore = { 0x0L, };
     protected SimpleCharStream input_stream;
 
-    private final int[] jjrounds = new int[30];
-    private final int[] jjstateSet = new int[2 * 30];
+    private final int[] jjrounds = new int[29];
+    private final int[] jjstateSet = new int[2 * 29];
     private final StringBuilder jjimage = new StringBuilder();
     private StringBuilder image = jjimage;
     private int jjimageLen;

--- a/java/org/apache/tomcat/util/http/parser/MediaType.java
+++ b/java/org/apache/tomcat/util/http/parser/MediaType.java
@@ -17,7 +17,7 @@
 package org.apache.tomcat.util.http.parser;
 
 import java.io.IOException;
-import java.io.StringReader;
+import java.io.Reader;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -124,7 +124,7 @@ public class MediaType {
      *
      * @throws IOException if there was a problem reading the input
      */
-    public static MediaType parseMediaType(StringReader input) throws IOException {
+    public static MediaType parseMediaType(Reader input) throws IOException {
 
         // Type (required)
         String type = HttpParser.readToken(input);
@@ -151,9 +151,11 @@ public class MediaType {
         while (lookForSemiColon == SkipResult.FOUND) {
             String attribute = HttpParser.readToken(input);
 
-            String value = "";
+            String value;
             if (HttpParser.skipConstant(input, "=") == SkipResult.FOUND) {
                 value = HttpParser.readTokenOrQuotedString(input, true);
+            } else {
+                value = "";
             }
 
             if (attribute != null) {

--- a/java/org/apache/tomcat/util/net/NioEndpoint.java
+++ b/java/org/apache/tomcat/util/net/NioEndpoint.java
@@ -634,7 +634,7 @@ public class NioEndpoint extends AbstractNetworkChannelEndpoint<NioChannel,Socke
         }
 
         public int getKeyCount() {
-            return keyCount;
+            return selector.keys().size();
         }
 
         public Selector getSelector() {

--- a/java/org/apache/tomcat/util/net/mbeans-descriptors.xml
+++ b/java/org/apache/tomcat/util/net/mbeans-descriptors.xml
@@ -147,6 +147,9 @@
     <attribute   name="useSendfile"
                  type="boolean"/>
 
+    <attribute   name="useVirtualThreads"
+                 type="boolean"/>
+
     <operation       name="addNegotiatedProtocol"
                returnType="void">
       <parameter name="param0"

--- a/test/org/apache/catalina/webresources/AbstractTestResourceSet.java
+++ b/test/org/apache/catalina/webresources/AbstractTestResourceSet.java
@@ -44,6 +44,10 @@ public abstract class AbstractTestResourceSet {
         return "";
     }
 
+    public String getMountPath() {
+        return "";
+    }
+
     public abstract File getBaseDir();
 
     @Before
@@ -77,23 +81,27 @@ public abstract class AbstractTestResourceSet {
 
 
     private void doTestGetResourceRoot(boolean slash) {
-        String mount = getMount();
-        if (!slash && mount.length() == 0) {
+        String mountPath = getMountPath();
+        if (!slash && mountPath.length() == 0) {
             return;
         }
-        mount = mount + (slash ? "/" : "");
+        String path = mountPath + (slash ? "/" : "");
 
-        WebResource webResource = resourceRoot.getResource(mount);
+        WebResource webResource = resourceRoot.getResource(path);
 
         Assert.assertTrue(webResource.isDirectory());
-        String expected;
-        if (getMount().length() > 0) {
-            expected = getMount().substring(1);
+        String expectedName;
+        if (getMountPath().length() > 0) {
+            expectedName = getMountPath().substring(1);
         } else {
-            expected = "";
+            expectedName = "";
         }
-        Assert.assertEquals(expected, webResource.getName());
-        Assert.assertEquals(mount + (!slash ? "/" : ""), webResource.getWebappPath());
+        String expectedPath = path;
+        if (!path.endsWith("/")) {
+            expectedPath += "/";
+        }
+        Assert.assertEquals(expectedName, webResource.getName());
+        Assert.assertEquals(expectedPath, webResource.getWebappPath());
     }
 
     @Test
@@ -101,7 +109,7 @@ public abstract class AbstractTestResourceSet {
         WebResource webResource = resourceRoot.getResource(getMount() + "/d1");
         Assert.assertTrue(webResource.isDirectory());
         Assert.assertEquals("d1", webResource.getName());
-        Assert.assertEquals(getMount() + "/d1/", webResource.getWebappPath());
+        Assert.assertEquals(getMountPath() + "/d1/", webResource.getWebappPath());
         Assert.assertEquals(-1, webResource.getContentLength());
         Assert.assertNull(webResource.getContent());
         Assert.assertNull(webResource.getInputStream());
@@ -112,7 +120,7 @@ public abstract class AbstractTestResourceSet {
         WebResource webResource = resourceRoot.getResource(getMount() + "/d1/");
         Assert.assertTrue(webResource.isDirectory());
         Assert.assertEquals("d1", webResource.getName());
-        Assert.assertEquals(getMount() + "/d1/", webResource.getWebappPath());
+        Assert.assertEquals(getMountPath() + "/d1/", webResource.getWebappPath());
         Assert.assertEquals(-1, webResource.getContentLength());
         Assert.assertNull(webResource.getContent());
         Assert.assertNull(webResource.getInputStream());
@@ -120,14 +128,15 @@ public abstract class AbstractTestResourceSet {
 
     @Test
     public final void testGetResourceDirWithoutLeadingFileSeperator() {
-        String mount = getMount();
-        if (mount.isEmpty()) {
+        // Use mount path for this test as the file separator needs to be missing
+        String mountPath = getMountPath();
+        if (mountPath.isEmpty()) {
             // Test is only meaningful when resource is mounted below web application root.
             return;
         }
-        WebResource webResource = resourceRoot.getResource(mount + "d1");
+        WebResource webResource = resourceRoot.getResource(mountPath + "d1");
         Assert.assertFalse(webResource.exists());
-        Assert.assertEquals(mount + "d1", webResource.getWebappPath());
+        Assert.assertEquals(getMountPath() + "d1", webResource.getWebappPath());
     }
 
     @Test
@@ -137,7 +146,7 @@ public abstract class AbstractTestResourceSet {
         Assert.assertTrue(webResource.isFile());
         Assert.assertEquals("d1-f1.txt", webResource.getName());
         Assert.assertEquals(
-                getMount() + "/d1/d1-f1.txt", webResource.getWebappPath());
+                getMountPath() + "/d1/d1-f1.txt", webResource.getWebappPath());
         Assert.assertEquals(0, webResource.getContentLength());
         Assert.assertEquals(0, webResource.getContent().length);
         Assert.assertNotNull(webResource.getInputStream());
@@ -293,18 +302,18 @@ public abstract class AbstractTestResourceSet {
         Set<String> results = resourceRoot.listWebAppPaths(mount + (slash ? "/" : ""));
 
         Set<String> expected = new HashSet<>();
-        expected.add(getMount() + "/d1/");
-        expected.add(getMount() + "/d2/");
-        expected.add(getMount() + "/f1.txt");
-        expected.add(getMount() + "/f2.txt");
+        expected.add(getMountPath() + "/d1/");
+        expected.add(getMountPath() + "/d2/");
+        expected.add(getMountPath() + "/f1.txt");
+        expected.add(getMountPath() + "/f2.txt");
 
         // Directories created by Subversion 1.6 and earlier clients
         Set<String> optional = new HashSet<>();
-        optional.add(getMount() + "/.svn/");
+        optional.add(getMountPath() + "/.svn/");
         // Files visible in some tests only
-        optional.add(getMount() + "/.ignore-me.txt");
+        optional.add(getMountPath() + "/.ignore-me.txt");
         // Files visible in some configurations only
-        optional.add(getMount() + "/META-INF/");
+        optional.add(getMountPath() + "/META-INF/");
 
         for (String result : results) {
             Assert.assertTrue(result,
@@ -318,7 +327,7 @@ public abstract class AbstractTestResourceSet {
         Set<String> results = resourceRoot.listWebAppPaths(getMount() + "/d1");
 
         Set<String> expected = new HashSet<>();
-        expected.add(getMount() + "/d1/d1-f1.txt");
+        expected.add(getMountPath() + "/d1/d1-f1.txt");
 
         // Directories created by Subversion 1.6 and earlier clients
         Set<String> optional = new HashSet<>();
@@ -338,7 +347,7 @@ public abstract class AbstractTestResourceSet {
         Set<String> results = resourceRoot.listWebAppPaths(getMount() + "/d1/");
 
         Set<String> expected = new HashSet<>();
-        expected.add(getMount() + "/d1/d1-f1.txt");
+        expected.add(getMountPath() + "/d1/d1-f1.txt");
 
         // Directories created by Subversion 1.6 and earlier clients
         Set<String> optional = new HashSet<>();

--- a/test/org/apache/catalina/webresources/AbstractTestResourceSetMountTrailing.java
+++ b/test/org/apache/catalina/webresources/AbstractTestResourceSetMountTrailing.java
@@ -25,12 +25,12 @@ import org.junit.Test;
 
 import org.apache.catalina.WebResource;
 
-public abstract class AbstractTestResourceSetMount
+public abstract class AbstractTestResourceSetMountTrailing
         extends AbstractTestResourceSet {
 
     @Override
     public final String getMount() {
-        return "/mount";
+        return "/mount/";
     }
 
     @Override
@@ -50,7 +50,7 @@ public abstract class AbstractTestResourceSetMount
 
         Assert.assertNotNull(results);
         Assert.assertEquals(1, results.length);
-        Assert.assertEquals(getMount().substring(1), results[0]);
+        Assert.assertEquals(getMountPath().substring(1), results[0]);
     }
 
     @Test
@@ -59,7 +59,7 @@ public abstract class AbstractTestResourceSetMount
 
         Assert.assertNotNull(results);
         Assert.assertEquals(1, results.size());
-        Assert.assertTrue(results.contains(getMount() + "/"));
+        Assert.assertTrue(results.contains(getMountPath() + "/"));
     }
 
     @Test

--- a/test/org/apache/catalina/webresources/TestDirResourceSetMount.java
+++ b/test/org/apache/catalina/webresources/TestDirResourceSetMount.java
@@ -52,7 +52,7 @@ public class TestDirResourceSetMount extends AbstractTestResourceSetMount {
     public WebResourceRoot getWebResourceRoot() {
         TesterWebResourceRoot root = new TesterWebResourceRoot();
         WebResourceSet webResourceSet =
-                new DirResourceSet(new TesterWebResourceRoot(), getMount(),
+                new DirResourceSet(new TesterWebResourceRoot(), getMount() + "/",
                         getBaseDir().getAbsolutePath(), "/");
         root.setMainResources(webResourceSet);
         return root;

--- a/test/org/apache/catalina/webresources/TestDirResourceSetMountTrailing.java
+++ b/test/org/apache/catalina/webresources/TestDirResourceSetMountTrailing.java
@@ -30,7 +30,7 @@ import org.apache.catalina.WebResourceSet;
 import org.apache.catalina.startup.ExpandWar;
 import org.apache.catalina.startup.TomcatBaseTest;
 
-public class TestDirResourceSetMount extends AbstractTestResourceSetMount {
+public class TestDirResourceSetMountTrailing extends AbstractTestResourceSetMountTrailing {
 
     private static Path tempDir;
     private static File dir1;

--- a/test/org/apache/catalina/webresources/TestJarResourceSetMountTrailing.java
+++ b/test/org/apache/catalina/webresources/TestJarResourceSetMountTrailing.java
@@ -17,69 +17,44 @@
 package org.apache.catalina.webresources;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 
 import org.apache.catalina.WebResourceRoot;
 import org.apache.catalina.WebResourceSet;
-import org.apache.catalina.startup.ExpandWar;
-import org.apache.catalina.startup.TomcatBaseTest;
 
-public class TestDirResourceSetMount extends AbstractTestResourceSetMount {
-
-    private static Path tempDir;
-    private static File dir1;
-
-    @BeforeClass
-    public static void before() throws IOException {
-        tempDir = Files.createTempDirectory("test", new FileAttribute[0]);
-        dir1 = new File(tempDir.toFile(), "dir1");
-        TomcatBaseTest.recursiveCopy(new File("test/webresources/dir1").toPath(), dir1.toPath());
-    }
-
-    @AfterClass
-    public static void after() {
-        ExpandWar.delete(tempDir.toFile());
-    }
-
+public class TestJarResourceSetMountTrailing extends AbstractTestResourceSetMount {
 
     @Override
     public WebResourceRoot getWebResourceRoot() {
+        File f = new File("test/webresources/dir1.jar");
         TesterWebResourceRoot root = new TesterWebResourceRoot();
         WebResourceSet webResourceSet =
-                new DirResourceSet(new TesterWebResourceRoot(), getMount(),
-                        getBaseDir().getAbsolutePath(), "/");
+                new JarResourceSet(root, getMount(), f.getAbsolutePath(), "/");
         root.setMainResources(webResourceSet);
         return root;
     }
 
     @Override
     protected boolean isWritable() {
-        return true;
+        return false;
     }
 
     @Override
     public File getBaseDir() {
-        return dir1;
+        return new File("test/webresources");
     }
 
     @Override
     protected String getNewDirName() {
-        return "test-dir-03";
+        return "test-dir-10";
     }
 
     @Override
     protected String getNewFileNameNull() {
-        return "test-null-03";
+        return "test-null-10";
     }
 
     @Override
     protected String getNewFileName() {
-        return "test-file-03";
+        return "test-file-10";
     }
 }

--- a/test/org/apache/el/parser/TesterGenerateIdentifierRanges.java
+++ b/test/org/apache/el/parser/TesterGenerateIdentifierRanges.java
@@ -61,11 +61,11 @@ public class TesterGenerateIdentifierRanges {
 
 
     /*
-     * Java Digit is all characters where Character.isJavaIdentifierPart(0 returns true that aren't included in Java
+     * Java Digit is all characters where Character.isJavaIdentifierPart() returns true that aren't included in Java
      * Letter.
      */
     @Test
-    public void testJavaDigitRanges() {
+    public void testGenerateJavaDigitRanges() {
         int start = 0;
         int end = 0;
         boolean inRange = false;

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -263,6 +263,12 @@
         <code>getUserX509CertificateChain()</code> that provides the client
         certificate chain, if present, during the WebSocket handshake. (markt)
       </add>
+      <fix>
+        Implement the clarification in WebSocket 2.3 that the method
+        <code>ClientEndpointConfig.Configurator.afterResponse()</code> must be
+        called after every WebSocket handshake regardless of whether the
+        handshake is successful or not. (markt)
+      </fix>
       <!-- Entries for backport and removal before 12.0.0-M1 below this line -->
     </changelog>
   </subsection>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -206,6 +206,10 @@
         Fix JMX value for <code>keepAliveCount</code> on the endpoint. Also add
         the value of <code>useVirtualThreads</code> in JMX. (remm)
       </fix>
+      <fix>
+        <bug>69717</bug>: Allow trailing slash for <code>webAppMount</code>
+        path in <code>Resources</code>, for compatibility reasons. (remm)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Jasper">

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -202,6 +202,10 @@
         request multiple times. Based on pull request <pr>868</pr> by
         qingdaoheze. (markt)
       </fix>
+      <fix>
+        Fix JMX value for <code>keepAliveCount</code> on the endpoint. Also add
+        the value of <code>useVirtualThreads</code> in JMX. (remm)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Jasper">

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -227,6 +227,10 @@
         <code>jakarta.el.ELResolver.StandaloneIdentifierMarker</code>. (markt)
       </scode>
       <!-- Entries for backport and removal before 12.0.0-M1 below this line -->
+      <scode>
+        Remove <code>IMPL_OBJ_START</code> from EL grammar for
+        <code>IDENTIFIER</code>. (markt)
+      </scode>
     </changelog>
   </subsection>
   <subsection name="Cluster">

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -175,6 +175,12 @@
         length is known, no content has been written and a <code>Writer</code>
         is being used. (markt)
       </fix>
+      <fix>
+        <bug>69717</bug>: Correct a regression in the fix for CVE-2025-49125
+        that prevented access to PreResources and PostResources when mounted
+        below the web application root with a path that was terminated with a
+        file separator. (remm/markt)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Coyote">
@@ -205,10 +211,6 @@
       <fix>
         Fix JMX value for <code>keepAliveCount</code> on the endpoint. Also add
         the value of <code>useVirtualThreads</code> in JMX. (remm)
-      </fix>
-      <fix>
-        <bug>69717</bug>: Allow trailing slash for <code>webAppMount</code>
-        path in <code>Resources</code>, for compatibility reasons. (remm)
       </fix>
     </changelog>
   </subsection>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -197,6 +197,11 @@
         <bug>69713</bug>: Correctly handle an HTTP/2 data frame that includes
         padding when the headers include a content-length. (remm/markt)
       </fix>
+      <fix>
+        Correctly collect statistics for HTTP/2 requests and avoid counting one
+        request multiple times. Based on pull request <pr>868</pr> by
+        qingdaoheze. (markt)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Jasper">

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -235,6 +235,10 @@
         Remove <code>IMPL_OBJ_START</code> from EL grammar for
         <code>IDENTIFIER</code>. (markt)
       </scode>
+      <scode>
+        Remove the <code>INSTANCEOF</code> and <code>FUNCTIONSUFFIX</code>
+        definitions from the EL grammar as both are unused. (markt)
+      </scode>
     </changelog>
   </subsection>
   <subsection name="Cluster">

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -258,6 +258,11 @@
         Update Tomcat's WebSocket support to version 2.3 of the Jakarta
         WebSocket API. (markt)
       </update>
+      <add>
+        Implement the new <code>HandshakeRequest</code> method,
+        <code>getUserX509CertificateChain()</code> that provides the client
+        certificate chain, if present, during the WebSocket handshake. (markt)
+      </add>
       <!-- Entries for backport and removal before 12.0.0-M1 below this line -->
     </changelog>
   </subsection>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -200,6 +200,12 @@
       </update>
       <!-- Entries for backport and removal before 12.0.0-M1 below this line -->
       <fix>
+        <bug>69710</bug>: Increase the default for <code>maxPartCount</code>
+        from <code>10</code> to <code>50</code>. Update the documentation to
+        provide more details on the memory requirements to support multi-part
+        uploads while avoiding a denial of service risk. (markt)
+      </fix>
+      <fix>
         <bug>69713</bug>: Correctly handle an HTTP/2 data frame that includes
         padding when the headers include a content-length. (remm/markt)
       </fix>

--- a/webapps/docs/config/ajp.xml
+++ b/webapps/docs/config/ajp.xml
@@ -190,7 +190,15 @@
       content type is <code>multipart/form-data</code>. This limit is in
       addition to <code>maxParameterCount</code>. Requests that exceed this
       limit will be rejected. A value of less than 0 means no limit. If not
-      specified, a default of 10 is used.</p>
+      specified, a default of 50 is used.</p>
+      <p>The nature of multipart requests and the associated Servlet API
+      requirements for processing them is such that they can place a significant
+      demand on memory. Applications utilising multipart requests need to ensure
+      sufficient memory is available to avoid a potential denial of service. As
+      a guide, the memory required is <code>maxPartHeaderSize</code> x
+      <code>maxPartCount</code> x <code>maxConnections</code> x 2 (due to the
+      implementation). For the defaults that is <code>512 x 50 x 8192 x 2</code>
+      which is 400MB.</p>
     </attribute>
 
     <attribute name="maxPartHeaderSize" required="false">

--- a/webapps/docs/config/http.xml
+++ b/webapps/docs/config/http.xml
@@ -186,7 +186,15 @@
       content type is <code>multipart/form-data</code>. This limit is in
       addition to <code>maxParameterCount</code>. Requests that exceed this
       limit will be rejected. A value of less than 0 means no limit. If not
-      specified, a default of 10 is used.</p>
+      specified, a default of 50 is used.</p>
+      <p>The nature of multipart requests and the associated Servlet API
+      requirements for processing them is such that they can place a significant
+      demand on memory. Applications utilising multipart requests need to ensure
+      sufficient memory is available to avoid a potential denial of service. As
+      a guide, the memory required is <code>maxPartHeaderSize</code> x
+      <code>maxPartCount</code> x <code>maxConnections</code> x 2 (due to the
+      implementation). For the defaults that is <code>512 x 50 x 8192 x 2</code>
+      which is 400MB.</p>
     </attribute>
 
     <attribute name="maxPartHeaderSize" required="false">

--- a/webapps/docs/security-howto.xml
+++ b/webapps/docs/security-howto.xml
@@ -271,10 +271,17 @@
       will interpret as UTF-7 a response containing characters that are safe for
       ISO-8859-1 but trigger an XSS vulnerability if interpreted as UTF-7.</p>
 
+      <p>The <strong>maxPartCount</strong> attribute controls the maximum number
+      of parts supported for a multipart request. This is limited to 50 by
+      default to reduce exposure to a DoS attack. The documentation for
+      <strong>maxPartCount</strong> provides more details on the memory
+      requirements for processing multipart requests. Requests with excessive
+      parts are rejected.</p>
+      
       <p>The <strong>maxPostSize</strong> attribute controls the maximum size
       of a POST request that will be parsed for parameters. The parameters are
       cached for the duration of the request so this is limited to 2 MiB by
-      default to reduce exposure to a DOS attack.</p>
+      default to reduce exposure to a DoS attack.</p>
 
       <p>The <strong>maxSavePostSize</strong> attribute controls the saving of
       the request body during FORM and CLIENT-CERT authentication and HTTP/1.1


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `a5deb26..d25055b`
**Files Changed:** 24 (18 programming files)
**Programming Ratio:** 75.0%

**Commits included:**
- More doc improvements for maxPartCount
- BZ 69710 Increase default maxPartCount to 50
- Always call Configurator.afterResponse() regardless of success/failure
- Update change log
- Fix BZ 69717 - expand test cases
- Allow trailing slash for webAppMount in Resources
- Add null coalescing operator to comment
- Remove the unused INSTANCEOF and FUNCTIONSUFFIX
- Fix JMX value for keepAliveCount
- Add change log entry
... and 5 more commits